### PR TITLE
Fix to compile and pass all tests in MinGW on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 
 ifeq ($(OS),Windows_NT)
 UNAME_S := $(OS)
+ifeq ($(shell gcc -dumpmachine),mingw32)
+MINGW_CXXFLAGS = -U__STRICT_ANSI__
+endif
 else
 UNAME_S := $(shell uname -s)
 endif
@@ -23,7 +26,7 @@ endif
 # changed if desired.
 
 PEGTL_CPPFLAGS ?= -pedantic
-PEGTL_CXXFLAGS ?= -Wall -Wextra -Werror -O3
+PEGTL_CXXFLAGS ?= -Wall -Wextra -Werror -O3 $(MINGW_CXXFLAGS)
 
 .PHONY: all clean
 

--- a/unit_tests/internal_file_mapper.cc
+++ b/unit_tests/internal_file_mapper.cc
@@ -7,6 +7,7 @@ namespace pegtl
 {
    void unit_test()
    {
+#if defined(_POSIX_MAPPED_FILES)
       try {
          internal::file_mapper( "pegtl" );
          std::cerr << "pegtl: unit test failed for [ internal::file_mapper ] " << std::endl;
@@ -14,6 +15,7 @@ namespace pegtl
       }
       catch ( const std::exception & ) {
       }
+#endif
    }
 
 } // pegtl

--- a/unit_tests/internal_file_opener.cc
+++ b/unit_tests/internal_file_opener.cc
@@ -7,6 +7,7 @@ namespace pegtl
 {
    void unit_test()
    {
+#if defined(_POSIX_MAPPED_FILES)
       const internal::file_opener fo( "Makefile" );
       ::close( fo.m_fd );  // Provoke exception, nobody would normally do this.
       try {
@@ -16,6 +17,7 @@ namespace pegtl
       }
       catch ( const std::exception & ) {
       }
+#endif
    }
 
 } // pegtl

--- a/unit_tests/verify_file.hh
+++ b/unit_tests/verify_file.hh
@@ -8,7 +8,8 @@
 
 namespace pegtl
 {
-   struct file_content : pegtl_string_t( "dummy content\n" ) {};
+   struct any_eol : sor< one< '\n' >, pegtl::string< '\r', '\n' >,	one< '\r' > > {};
+   struct file_content : seq< pegtl_string_t( "dummy content" ), any_eol > {};
    struct file_grammar : seq< rep_min_max< 11, 11, file_content >, eof > {};
 
    template< typename Rule > struct file_action : nothing< Rule > {};


### PR DESCRIPTION
The gcc 4.9.3 include files on MinGW guard all non-Ansi functions with '#ifndef __STRICT_ANSI__', causing compilation errors in functions like strcasecmp(); fix by adding '-U__STRICT_ANSI__' option if
'gcc -dumpmachine' returns 'mingw32'.

internal::file_mapper and internal::file_opener are only defined if mmap() exists; guard the corresponding tests with '#if defined(_POSIX_MAPPED_FILES)'.

verify_file assumes that the data input file has Unix line endings, which is not true on Win32 and causes test failures; fix by modifying the grammar to include:
  struct any_eol : sor< one< '\n' >, pegtl::string< '\r', '\n' >,	one< '\r' > > {};

Maybe any_eol could be included in ascci.hh?
