### PR TITLE
Fix test for Win32 line ending

### DIFF
--- a/unit_tests/verify_file.hh
+++ b/unit_tests/verify_file.hh
@@ -8,7 +8,7 @@
 
 namespace pegtl
 {
-   struct file_content : pegtl_string_t( "dummy content\n" ) {};
+   struct file_content : seq< pegtl_string_t( "dummy content" ), eol > {};
    struct file_grammar : seq< rep_min_max< 11, 11, file_content >, eof > {};
 
    template< typename Rule > struct file_action : nothing< Rule > {};


### PR DESCRIPTION
On Win32 the end of line is coded as "\r\n", need to match rule eol
instead of "\n".