### PR TITLE
Support Mac OS style line ending

### DIFF
--- a/pegtl/internal/eol.hh
+++ b/pegtl/internal/eol.hh
@@ -33,8 +33,13 @@ namespace pegtl
                in.bump_next_line();
                return true;
             }
-            if ( ( a == '\r' ) && ( s > 1 ) && ( in.peek_char( 1 ) == '\n' ) ) {
-               in.bump_next_line( 2 );
+            if ( a == '\r' ) {
+               if ( ( s > 1 ) && ( in.peek_char( 1 ) == '\n' ) ) {
+                  in.bump_next_line( 2 );
+               }
+               else {
+                  in.bump_next_line();
+               }
                return true;
             }
             return false;

--- a/unit_tests/ascii_classes.cc
+++ b/unit_tests/ascii_classes.cc
@@ -67,7 +67,7 @@ namespace pegtl
          const bool is_upper = ( 'A' <= i ) && ( i <= 'Z' );
          const bool is_xalpha = ( ( 'a' <= i ) && ( i <= 'f' ) ) || ( ( 'A' <= i ) && ( i <= 'F' ) );
 
-         const bool is_newline = ( i == '\n' );
+         const bool is_newline = ( i == '\n' ) || ( i == '\r' );
 
          const bool is_ident_first = ( i == '_' ) || is_lower || is_upper;
          const bool is_ident_other = is_ident_first || is_digit;

--- a/unit_tests/ascii_eol.cc
+++ b/unit_tests/ascii_eol.cc
@@ -12,15 +12,22 @@ namespace pegtl
       verify_rule< eol >( __LINE__, __FILE__,  "", result_type::LOCAL_FAILURE, 0 );
 
       for ( char i = 1; i < 127; ++i ) {
-         verify_char< eol >( __LINE__, __FILE__, i, ( i == '\n' ) ? result_type::SUCCESS : result_type::LOCAL_FAILURE );
+         verify_char< eol >( __LINE__, __FILE__, i, (( i == '\n' ) || ( i == '\r' )) ? result_type::SUCCESS : result_type::LOCAL_FAILURE );
       }
       verify_rule< eol >( __LINE__, __FILE__,  "\r\n", result_type::SUCCESS, 0 );
       verify_rule< eol >( __LINE__, __FILE__,  "\n\r", result_type::SUCCESS, 1 );
       verify_rule< eol >( __LINE__, __FILE__,  "\na", result_type::SUCCESS, 1 );
-      verify_rule< eol >( __LINE__, __FILE__,  "\ra", result_type::LOCAL_FAILURE, 2 );
+      verify_rule< eol >( __LINE__, __FILE__,  "\ra", result_type::SUCCESS, 1 );
       verify_rule< eol >( __LINE__, __FILE__,  "\r\na", result_type::SUCCESS, 1 );
+      verify_rule< eol >( __LINE__, __FILE__,  "\n\ra", result_type::SUCCESS, 2 );
+      verify_rule< eol >( __LINE__, __FILE__,  "\r\r\r", result_type::SUCCESS, 2 );
+      verify_rule< eol >( __LINE__, __FILE__,  "\r\r\n", result_type::SUCCESS, 2 );
       verify_rule< eol >( __LINE__, __FILE__,  "\r\n\r", result_type::SUCCESS, 1 );
       verify_rule< eol >( __LINE__, __FILE__,  "\r\n\n", result_type::SUCCESS, 1 );
+      verify_rule< eol >( __LINE__, __FILE__,  "\n\r\r", result_type::SUCCESS, 2 );
+      verify_rule< eol >( __LINE__, __FILE__,  "\n\r\n", result_type::SUCCESS, 2 );
+      verify_rule< eol >( __LINE__, __FILE__,  "\n\n\r", result_type::SUCCESS, 2 );
+      verify_rule< eol >( __LINE__, __FILE__,  "\n\n\n", result_type::SUCCESS, 2 );
    }
 
 } // pegtl

--- a/unit_tests/ascii_eolf.cc
+++ b/unit_tests/ascii_eolf.cc
@@ -12,15 +12,22 @@ namespace pegtl
       verify_rule< eolf >( __LINE__, __FILE__,  "", result_type::SUCCESS, 0 );
 
       for ( char i = 1; i < 127; ++i ) {
-         verify_char< eolf >( __LINE__, __FILE__, i, ( i == '\n' ) ? result_type::SUCCESS : result_type::LOCAL_FAILURE );
+         verify_char< eolf >( __LINE__, __FILE__, i, (( i == '\n' ) || ( i == '\r' )) ? result_type::SUCCESS : result_type::LOCAL_FAILURE );
       }
       verify_rule< eolf >( __LINE__, __FILE__,  "\r\n", result_type::SUCCESS, 0 );
       verify_rule< eolf >( __LINE__, __FILE__,  "\n\r", result_type::SUCCESS, 1 );
       verify_rule< eolf >( __LINE__, __FILE__,  "\na", result_type::SUCCESS, 1 );
-      verify_rule< eolf >( __LINE__, __FILE__,  "\ra", result_type::LOCAL_FAILURE, 2 );
+      verify_rule< eolf >( __LINE__, __FILE__,  "\ra", result_type::SUCCESS, 1 );
       verify_rule< eolf >( __LINE__, __FILE__,  "\r\na", result_type::SUCCESS, 1 );
+      verify_rule< eolf >( __LINE__, __FILE__,  "\n\ra", result_type::SUCCESS, 2 );
+      verify_rule< eolf >( __LINE__, __FILE__,  "\r\r\r", result_type::SUCCESS, 2 );
+      verify_rule< eolf >( __LINE__, __FILE__,  "\r\r\n", result_type::SUCCESS, 2 );
       verify_rule< eolf >( __LINE__, __FILE__,  "\r\n\r", result_type::SUCCESS, 1 );
       verify_rule< eolf >( __LINE__, __FILE__,  "\r\n\n", result_type::SUCCESS, 1 );
+      verify_rule< eolf >( __LINE__, __FILE__,  "\n\r\r", result_type::SUCCESS, 2 );
+      verify_rule< eolf >( __LINE__, __FILE__,  "\n\r\n", result_type::SUCCESS, 2 );
+      verify_rule< eolf >( __LINE__, __FILE__,  "\n\n\r", result_type::SUCCESS, 2 );
+      verify_rule< eolf >( __LINE__, __FILE__,  "\n\n\n", result_type::SUCCESS, 2 );
    }
 
 } // pegtl


### PR DESCRIPTION
OS X style line ending is just '\r'.
This patch adds support for this line ending style.