### PR TITLE
Add -Wshadow to default compilation flags and fix a few occurrences.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 # changed if desired.
 
 PEGTL_CPPFLAGS ?= -pedantic
-PEGTL_CXXFLAGS ?= -Wall -Wextra -Werror -O3 $(MINGW_CXXFLAGS)
+PEGTL_CXXFLAGS ?= -Wall -Wextra -Werror -Wshadow -O3 $(MINGW_CXXFLAGS)
 
 .PHONY: all clean
 

--- a/examples/json_build_one.cc
+++ b/examples/json_build_one.cc
@@ -91,12 +91,12 @@ namespace examples
          result.reset();
       }
 
-      void success( result_state & result )
+      void success( result_state & in_result )
       {
          if ( this->result ) {
             push_back();
          }
-         result.result = array;
+         in_result.result = array;
       }
    };
 
@@ -127,12 +127,12 @@ namespace examples
          result.reset();
       }
 
-      void success( result_state & result )
+      void success( result_state & in_result )
       {
          if ( this->result ) {
             insert();
          }
-         result.result = object;
+         in_result.result = object;
       }
    };
 

--- a/examples/json_classes.hh
+++ b/examples/json_classes.hh
@@ -31,8 +31,8 @@ namespace examples
 
    protected:
       explicit
-      json_base( const json_type type )
-            : type( type )
+      json_base( const json_type in_type )
+            : type( in_type )
       { }
 
       ~json_base()
@@ -77,9 +77,9 @@ namespace examples
          : public json_base
    {
       explicit
-      boolean_json( const bool data)
+      boolean_json( const bool in_data)
             : json_base( json_type::BOOLEAN ),
-              data( data )
+              data( in_data )
       { }
 
       bool data;
@@ -107,9 +107,9 @@ namespace examples
          : public json_base
    {
       explicit
-      number_json( const long double data )
+      number_json( const long double in_data )
             : json_base( json_type::NUMBER ),
-              data( data )
+              data( in_data )
       { }
 
       long double data;
@@ -172,9 +172,9 @@ namespace examples
          : public json_base
    {
       explicit
-      string_json( const std::string & data )
+      string_json( const std::string & in_data )
             : json_base( json_type::STRING ),
-              data( data )
+              data( in_data )
       { }
 
       std::string data;

--- a/pegtl/action_input.hh
+++ b/pegtl/action_input.hh
@@ -15,8 +15,8 @@ namespace pegtl
    class action_input
    {
    public:
-      action_input( const std::size_t line, const std::size_t byte_in_line, const char * begin, const char * end, const char * source )
-            : m_data( line, byte_in_line, begin, end, source )
+      action_input( const std::size_t in_line, const std::size_t in_byte_in_line, const char * in_begin, const char * in_end, const char * in_source )
+            : m_data( in_line, in_byte_in_line, in_begin, in_end, in_source )
       { }
 
       bool empty() const

--- a/pegtl/analysis/rule_info.hh
+++ b/pegtl/analysis/rule_info.hh
@@ -16,8 +16,8 @@ namespace pegtl
       struct rule_info
       {
          explicit
-         rule_info( const rule_type type )
-               : type( type )
+         rule_info( const rule_type in_type )
+               : type( in_type )
          { }
 
          rule_type type;

--- a/pegtl/buffer_input.hh
+++ b/pegtl/buffer_input.hh
@@ -18,11 +18,11 @@ namespace pegtl
    {
    public:
       template< typename ... As >
-      buffer_input( const char * source, const std::size_t maximum, As && ... as )
+      buffer_input( const char * in_source, const std::size_t maximum, As && ... as )
             : m_reader( std::forward< As >( as ) ... ),
               m_maximum( maximum ),
               m_buffer( new char[ maximum ] ),
-              m_data( 1, 0, m_buffer.get(), m_buffer.get(), source )
+              m_data( 1, 0, m_buffer.get(), m_buffer.get(), in_source )
 
       { }
 

--- a/pegtl/input_error.hh
+++ b/pegtl/input_error.hh
@@ -13,9 +13,9 @@ namespace pegtl
    struct input_error
          : std::runtime_error
    {
-      input_error( const std::string & message, const int errorno )
+      input_error( const std::string & message, const int in_errorno )
             : std::runtime_error( message ),
-              errorno( errorno )
+              errorno( in_errorno )
       { }
 
       int errorno;

--- a/pegtl/internal/input_data.hh
+++ b/pegtl/internal/input_data.hh
@@ -12,12 +12,12 @@ namespace pegtl
    {
       struct input_data
       {
-         input_data( const std::size_t line, const std::size_t byte_in_line, const char * begin, const char * end, const char * source )
-               : line( line ),
-                 byte_in_line( byte_in_line ),
-                 begin( begin ),
-                 end( end ),
-                 source( source )
+         input_data( const std::size_t in_line, const std::size_t in_byte_in_line, const char * in_begin, const char * in_end, const char * in_source )
+               : line( in_line ),
+                 byte_in_line( in_byte_in_line ),
+                 begin( in_begin ),
+                 end( in_end ),
+                 source( in_source )
          { }
 
          std::size_t line;

--- a/pegtl/memory_input.hh
+++ b/pegtl/memory_input.hh
@@ -20,8 +20,8 @@ namespace pegtl
             : m_data( data )
       { }
 
-      memory_input( const std::size_t line, const std::size_t byte_in_line, const char * begin, const char * end, const char * source )
-            : m_data( line, byte_in_line, begin, end, source )
+      memory_input( const std::size_t in_line, const std::size_t in_byte_in_line, const char * in_begin, const char * in_end, const char * in_source )
+            : m_data( in_line, in_byte_in_line, in_begin, in_end, in_source )
       { }
 
       bool empty() const

--- a/pegtl/parse_error.hh
+++ b/pegtl/parse_error.hh
@@ -14,9 +14,9 @@ namespace pegtl
    struct parse_error
          : public std::runtime_error
    {
-      parse_error( const std::string & message, std::vector< position_info > && positions )
+      parse_error( const std::string & message, std::vector< position_info > && in_positions )
             : std::runtime_error( message ),
-              positions( std::move( positions ) )
+              positions( std::move( in_positions ) )
       { }
 
       template< typename Input >

--- a/pegtl/string_parser.hh
+++ b/pegtl/string_parser.hh
@@ -16,9 +16,9 @@ namespace pegtl
    class string_parser
    {
    public:
-      string_parser( std::string data, std::string source, const std::size_t line = 1, const std::size_t byte_in_line = 0 )
+      string_parser( std::string data, std::string in_source, const std::size_t line = 1, const std::size_t byte_in_line = 0 )
             : m_data( std::move( data ) ),
-              m_source( std::move( source ) ),
+              m_source( std::move( in_source ) ),
               m_input( line, byte_in_line, m_data.data(), m_data.data() + m_data.size(), m_source.c_str() )
       { }
 


### PR DESCRIPTION
This is not a grave warning, but since it does help find real bugs, there are great chances that a project using the PEGTL would use `-Wshadow` by default. I suggest using it by default, too.