### PR TITLE
Expose raw byte position in position information.

### DIFF
--- a/pegtl/action_input.hh
+++ b/pegtl/action_input.hh
@@ -15,8 +15,8 @@ namespace pegtl
    class action_input
    {
    public:
-      action_input( const std::size_t in_line, const std::size_t in_byte_in_line, const char * in_begin, const char * in_end, const char * in_source )
-            : m_data( in_line, in_byte_in_line, in_begin, in_end, in_source )
+      action_input( const std::size_t in_byte, const std::size_t in_line, const std::size_t in_byte_in_line, const char * in_begin, const char * in_end, const char * in_source )
+            : m_data( in_byte, in_line, in_byte_in_line, in_begin, in_end, in_source )
       { }
 
       bool empty() const
@@ -37,6 +37,11 @@ namespace pegtl
       const char * end( const size_t = 0 ) const
       {
          return m_data.end;
+      }
+
+      std::size_t byte() const
+      {
+         return m_data.byte;
       }
 
       std::size_t line() const

--- a/pegtl/buffer_input.hh
+++ b/pegtl/buffer_input.hh
@@ -22,7 +22,7 @@ namespace pegtl
             : m_reader( std::forward< As >( as ) ... ),
               m_maximum( maximum ),
               m_buffer( new char[ maximum ] ),
-              m_data( 1, 0, m_buffer.get(), m_buffer.get(), in_source )
+              m_data( 0, 1, 0, m_buffer.get(), m_buffer.get(), in_source )
 
       { }
 
@@ -50,6 +50,11 @@ namespace pegtl
       {
          require( amount );
          return m_data.end;
+      }
+
+      std::size_t byte() const
+      {
+         return m_data.byte;
       }
 
       std::size_t line() const

--- a/pegtl/contrib/raw_string.hh
+++ b/pegtl/contrib/raw_string.hh
@@ -28,7 +28,8 @@ namespace pegtl
       {
          template< typename Input, typename ... States >
          raw_string_state( const Input & in, States && ... )
-               : line( in.line() ),
+               : byte( in.byte() ),
+                 line( in.line() ),
                  byte_in_line( in.byte_in_line() ),
                  size( in.size( 0 ) )
          { }
@@ -38,7 +39,7 @@ namespace pegtl
          success( const Input & in, States && ... st ) const
          {
             const auto * const begin = in.begin() - size + in.size( 0 ) + count;
-            action_input content( line, byte_in_line, begin + ( ( * begin ) == '\n' ), in.begin() - count, in.source() );
+            action_input content( byte, line, byte_in_line, begin + ( ( * begin ) == '\n' ), in.begin() - count, in.source() );
             Action< Tag >::apply( const_cast< const action_input & >( content ), st ... );
          }
 
@@ -50,6 +51,7 @@ namespace pegtl
          raw_string_state( const raw_string_state & ) = delete;
          void operator= ( const raw_string_state & ) = delete;
 
+         std::size_t byte;
          std::size_t line;
          std::size_t byte_in_line;
          std::size_t size;

--- a/pegtl/internal/input_data.hh
+++ b/pegtl/internal/input_data.hh
@@ -12,14 +12,16 @@ namespace pegtl
    {
       struct input_data
       {
-         input_data( const std::size_t in_line, const std::size_t in_byte_in_line, const char * in_begin, const char * in_end, const char * in_source )
-               : line( in_line ),
+         input_data( const std::size_t in_byte, const std::size_t in_line, const std::size_t in_byte_in_line, const char * in_begin, const char * in_end, const char * in_source )
+               : byte( in_byte ),
+                 line( in_line ),
                  byte_in_line( in_byte_in_line ),
                  begin( in_begin ),
                  end( in_end ),
                  source( in_source )
          { }
 
+         std::size_t byte;
          std::size_t line;
          std::size_t byte_in_line;
 
@@ -38,11 +40,13 @@ namespace pegtl
                   ++byte_in_line;
                }
             }
+            byte += count;
             begin += count;
          }
 
          void bump_in_this_line( const std::size_t count )
          {
+            byte += count;
             begin += count;
             byte_in_line += count;
          }
@@ -50,6 +54,7 @@ namespace pegtl
          void bump_to_next_line( const std::size_t count )
          {
             ++line;
+            byte += count;
             begin += count;
             byte_in_line = 0;
          }

--- a/pegtl/internal/input_mark.hh
+++ b/pegtl/internal/input_mark.hh
@@ -15,14 +15,16 @@ namespace pegtl
       public:
          explicit
          input_mark( input_data & i )
-               : m_line( i.line ),
+               : m_byte( i.byte ),
+                 m_line( i.line ),
                  m_byte_in_line( i.byte_in_line ),
                  m_begin( i.begin ),
                  m_input( & i )
          { }
 
          input_mark( input_mark && i ) noexcept
-               : m_line( i.m_line ),
+               : m_byte( i.m_byte ),
+                 m_line( i.m_line ),
                  m_byte_in_line( i.m_byte_in_line ),
                  m_begin( i.m_begin ),
                  m_input( i.m_input )
@@ -33,6 +35,7 @@ namespace pegtl
          ~input_mark()
          {
             if ( m_input != nullptr ) {
+               m_input->byte = m_byte;
                m_input->line = m_line;
                m_input->byte_in_line = m_byte_in_line;
                m_input->begin = m_begin;
@@ -51,6 +54,11 @@ namespace pegtl
             return false;
          }
 
+         std::size_t byte() const
+         {
+            return m_byte;
+         }
+
          std::size_t line() const
          {
             return m_line;
@@ -67,6 +75,7 @@ namespace pegtl
          }
 
       private:
+         const std::size_t m_byte;
          const std::size_t m_line;
          const std::size_t m_byte_in_line;
          const char * const m_begin;

--- a/pegtl/internal/minus.hh
+++ b/pegtl/internal/minus.hh
@@ -26,7 +26,7 @@ namespace pegtl
             if ( ! Control< M >::template match< A, Action, Control >( in, st ... ) ) {
                return false;
             }
-            memory_input i2( m.line(), m.byte_in_line(), m.begin(), in.begin(), in.source() );
+            memory_input i2( m.byte(), m.line(), m.byte_in_line(), m.begin(), in.begin(), in.source() );
 
             if ( ! Control< S >::template match< apply_mode::NOTHING, Action, Control >( i2, st ... ) ) {
                return m( true );

--- a/pegtl/internal/rule_match_two.hh
+++ b/pegtl/internal/rule_match_two.hh
@@ -52,7 +52,7 @@ namespace pegtl
             auto m = in.mark();
 
             if ( rule_match_two< Rule, A, Action, Control, false >::match( in, st ... ) ) {
-               Action< Rule >::apply( action_input( m.line(), m.byte_in_line(), m.begin(), in.begin(), in.source() ), st ... );
+               Action< Rule >::apply( action_input( m.byte(), m.line(), m.byte_in_line(), m.begin(), in.begin(), in.source() ), st ... );
                return m( true );
             }
             return false;

--- a/pegtl/memory_input.hh
+++ b/pegtl/memory_input.hh
@@ -21,8 +21,8 @@ namespace pegtl
             : m_data( data )
       { }
 
-      memory_input( const std::size_t in_line, const std::size_t in_byte_in_line, const char * in_begin, const char * in_end, const char * in_source )
-            : m_data( in_line, in_byte_in_line, in_begin, in_end, in_source )
+      memory_input( const std::size_t in_byte, const std::size_t in_line, const std::size_t in_byte_in_line, const char * in_begin, const char * in_end, const char * in_source )
+            : m_data( in_byte, in_line, in_byte_in_line, in_begin, in_end, in_source )
       { }
 
       bool empty() const
@@ -43,6 +43,11 @@ namespace pegtl
       const char * end( const size_t ) const
       {
          return m_data.end;
+      }
+
+      std::size_t byte() const
+      {
+         return m_data.byte;
       }
 
       std::size_t line() const

--- a/pegtl/mmap_parser.hh
+++ b/pegtl/mmap_parser.hh
@@ -21,7 +21,7 @@ namespace pegtl
       mmap_parser( const std::string & filename )
             : m_file( filename ),
               m_source( filename ),
-              m_input( 1, 0, m_file.begin(), m_file.end(), m_source.c_str() )
+              m_input( 0, 1, 0, m_file.begin(), m_file.end(), m_source.c_str() )
       { }
 
       const std::string & source() const

--- a/pegtl/parse.hh
+++ b/pegtl/parse.hh
@@ -33,14 +33,14 @@ namespace pegtl
       os << "argv[" << argn << ']';
       const std::string source = os.str();
       assert( argv[ argn ] );
-      memory_input in( 1, 0, argv[ argn ], argv[ argn ] + std::strlen( argv[ argn ] ), source.c_str() );
+      memory_input in( 0, 1, 0, argv[ argn ], argv[ argn ] + std::strlen( argv[ argn ] ), source.c_str() );
       return parse_input< Rule, Action, Control >( in, st ... );
    }
 
    template< typename Rule, template< typename ... > class Action = nothing, template< typename ... > class Control = normal, typename ... States >
    bool parse_memory( const char * data, const char * dend, const char * source, States && ... st )
    {
-      memory_input in( 1, 0, data, dend, source );
+      memory_input in( 0, 1, 0, data, dend, source );
       return parse_input< Rule, Action, Control >( in, st ... );
    }
 
@@ -98,7 +98,7 @@ namespace pegtl
    template< typename Rule, template< typename ... > class Action = nothing, template< typename ... > class Control = normal, typename Outer, typename ... States >
    bool parse_memory_nested( const Outer & oi, const char * data, const char * dend, const char * source, States && ... st )
    {
-      memory_input in( 1, 0, data, dend, source );
+      memory_input in( 0, 1, 0, data, dend, source );
       return parse_input_nested< Rule, Action, Control >( oi, in, st ... );
    }
 

--- a/pegtl/position_info.hh
+++ b/pegtl/position_info.hh
@@ -16,11 +16,13 @@ namespace pegtl
       template< typename Input >
       explicit
       position_info( const Input & in )
-            : line( in.line() ),
+            : byte( in.byte() ),
+              line( in.line() ),
               byte_in_line( in.byte_in_line() ),
               source( in.source() )
       { }
 
+      std::size_t byte;
       std::size_t line;
       std::size_t byte_in_line;
       std::string source;
@@ -28,7 +30,7 @@ namespace pegtl
 
    inline std::ostream & operator<< ( std::ostream & o, const position_info & p )
    {
-      return o << p.source << ':' << p.line << ':' << p.byte_in_line;
+      return o << p.source << ':' << p.line << ':' << p.byte_in_line << '(' << p.byte << ')';
    }
 
    inline std::string to_string( const position_info & p )

--- a/pegtl/string_parser.hh
+++ b/pegtl/string_parser.hh
@@ -16,10 +16,10 @@ namespace pegtl
    class string_parser
    {
    public:
-      string_parser( std::string data, std::string in_source, const std::size_t line = 1, const std::size_t byte_in_line = 0 )
+      string_parser( std::string data, std::string in_source, const std::size_t byte = 0, const std::size_t line = 1, const std::size_t byte_in_line = 0 )
             : m_data( std::move( data ) ),
               m_source( std::move( in_source ) ),
-              m_input( line, byte_in_line, m_data.data(), m_data.data() + m_data.size(), m_source.c_str() )
+              m_input( byte, line, byte_in_line, m_data.data(), m_data.data() + m_data.size(), m_source.c_str() )
       { }
 
       const std::string & source() const

--- a/unit_tests/contrib_raw_string.cc
+++ b/unit_tests/contrib_raw_string.cc
@@ -28,7 +28,7 @@ namespace pegtl
    void verify_data( const std::size_t line, const char * file, const char ( & m )[ M ], const char ( & n )[ N ] )
    {
       content.clear();
-      memory_input i( line, 0, m, m + M - 1, file );
+      memory_input i( 0, line, 0, m, m + M - 1, file );
       const auto r = parse_input< Rule, rsaction >( i );
       if ( ( ! r ) || ( content != std::string( n, N - 1 ) ) ) {
          TEST_FAILED( "input data [ '" << m << "' ] expected success with [ '" << n << "' ] but got [ '" << content << "' ] result [ " << r << " ]" );

--- a/unit_tests/position.cc
+++ b/unit_tests/position.cc
@@ -10,9 +10,10 @@ namespace pegtl
    {
       static const std::string s1 = "\n";
 
-      memory_input i1( 1, 0, s1.data(), s1.data() + s1.size(), __FUNCTION__ );
+      memory_input i1( 0, 1, 0, s1.data(), s1.data() + s1.size(), __FUNCTION__ );
 
       TEST_ASSERT( parse_input< Rule >( i1 ) );
+      TEST_ASSERT( i1.byte() == 1 );
       TEST_ASSERT( i1.line() == 2 );
       TEST_ASSERT( i1.byte_in_line() == 0 );
    }
@@ -22,9 +23,10 @@ namespace pegtl
    {
       TEST_ASSERT( s2.size() == 1 );
 
-      memory_input i2( 1, 0, s2.data(), s2.data() + s2.size(), __FUNCTION__ );
+      memory_input i2( 0, 1, 0, s2.data(), s2.data() + s2.size(), __FUNCTION__ );
 
       TEST_ASSERT( parse_input< Rule >( i2 ) );
+      TEST_ASSERT( i2.byte() == 1 );
       TEST_ASSERT( i2.line() == 1 );
       TEST_ASSERT( i2.byte_in_line() == 1 );
    }
@@ -34,9 +36,10 @@ namespace pegtl
    {
       TEST_ASSERT( s3.size() == 1 );
 
-      memory_input i3( 1, 0, s3.data(), s3.data() + s3.size(), __FUNCTION__ );
+      memory_input i3( 0, 1, 0, s3.data(), s3.data() + s3.size(), __FUNCTION__ );
 
       TEST_ASSERT( ! parse_input< Rule >( i3 ) );
+      TEST_ASSERT( i3.byte() == 0 );
       TEST_ASSERT( i3.line() == 1 );
       TEST_ASSERT( i3.byte_in_line() == 0 );
    }
@@ -56,6 +59,7 @@ namespace pegtl
       {
          const position_info p( in );
          TEST_ASSERT( p.source == "outer" );
+         TEST_ASSERT( p.byte == 2 );
          TEST_ASSERT( p.line == 1 );
          TEST_ASSERT( p.byte_in_line == 2 );
          parse_string_nested< inner_grammar >( in, "dFF", "inner" );
@@ -70,9 +74,11 @@ namespace pegtl
       catch ( const parse_error & e ) {
          TEST_ASSERT( e.positions.size() == 2 );
          TEST_ASSERT( e.positions[ 0 ].source == "inner" );
+         TEST_ASSERT( e.positions[ 0 ].byte == 1 );
          TEST_ASSERT( e.positions[ 0 ].line == 1 );
          TEST_ASSERT( e.positions[ 0 ].byte_in_line == 1 );
          TEST_ASSERT( e.positions[ 1 ].source == "outer" );
+         TEST_ASSERT( e.positions[ 1 ].byte == 2 );
          TEST_ASSERT( e.positions[ 1 ].line == 1 );
          TEST_ASSERT( e.positions[ 1 ].byte_in_line == 2 );
       }

--- a/unit_tests/verify_impl.hh
+++ b/unit_tests/verify_impl.hh
@@ -17,7 +17,7 @@ namespace pegtl
    template< typename Rule >
    void verify_impl( const std::size_t line, const char * file, const std::string & data, const result_type expected, const std::size_t remain )
    {
-      memory_input i( line, 0, data.data(), data.data() + data.size(), file );
+      memory_input i( 0, line, 0, data.data(), data.data() + data.size(), file );
 
       const result_type received = verify_help< Rule >( i );
 


### PR DESCRIPTION
In some cases it may be desirable to know the byte offset in addition
to the line / column information, for instance when parsing binary
files, or when feeding the parser with partial data.
