### PR TITLE
Generalized action input

### DIFF
--- a/pegtl/action_input.hh
+++ b/pegtl/action_input.hh
@@ -18,6 +18,11 @@ namespace pegtl
    class basic_action_input
    {
    public:
+
+      basic_action_input( const std::size_t in_line, const std::size_t in_byte_in_line, const char * in_begin, const char * in_end, const char * in_source )
+            : m_data( in_line, in_byte_in_line, in_begin, in_end, in_source )
+      { }
+
       basic_action_input( const internal::input_mark& from, const internal::input_mark& to )
             : m_data( from.line(), from.byte_in_line(), from.begin(), to.begin(), from.source() )
       { }

--- a/pegtl/action_input.hh
+++ b/pegtl/action_input.hh
@@ -15,8 +15,8 @@ namespace pegtl
    class action_input
    {
    public:
-      action_input( const std::size_t in_line, const std::size_t in_byte_in_line, const char * in_begin, const char * in_end, const char * in_source )
-            : m_data( in_line, in_byte_in_line, in_begin, in_end, in_source )
+      action_input( const internal::input_mark& from, const internal::input_mark& to )
+            : m_data( from.line(), from.byte_in_line(), from.begin(), to.begin(), from.source() )
       { }
 
       bool empty() const

--- a/pegtl/internal/input_mark.hh
+++ b/pegtl/internal/input_mark.hh
@@ -66,6 +66,11 @@ namespace pegtl
             return m_begin;
          }
 
+         const char * source() const
+         {
+             return m_input->source;
+         }
+
       private:
          const std::size_t m_line;
          const std::size_t m_byte_in_line;

--- a/pegtl/internal/rule_match_two.hh
+++ b/pegtl/internal/rule_match_two.hh
@@ -50,9 +50,10 @@ namespace pegtl
          static bool match( Input & in, States && ... st )
          {
             auto m = in.mark();
+            using Fragment = typename Input::Fragment;
 
             if ( rule_match_two< Rule, A, Action, Control, false >::match( in, st ... ) ) {
-               Action< Rule >::apply( action_input( m.line(), m.byte_in_line(), m.begin(), in.begin(), in.source() ), st ... );
+               Action< Rule >::apply( Fragment( m, in.mark() ), st ... );
                return m( true );
             }
             return false;

--- a/pegtl/memory_input.hh
+++ b/pegtl/memory_input.hh
@@ -13,8 +13,13 @@
 
 namespace pegtl
 {
+   class action_input;
+
    class memory_input
    {
+   public:
+      using Fragment = action_input;
+
    public:
       explicit
       memory_input( const internal::input_data & data )


### PR DESCRIPTION
Some inputs are not char-based, therefore basic_action_input cannot be used.
This change provides a more general approach while keeping the default behaviour intact.

In our project for performance reasons we use multi-pass parsing. First pass is a usual char-based lexer pass which splits input file into tokens, then this token stream is fed to the second pass, to token parser.

This change is needed for this second pass parser.