### PR TITLE
Empty file is OK

### DIFF
--- a/pegtl/internal/file_mapper.hh
+++ b/pegtl/internal/file_mapper.hh
@@ -27,7 +27,7 @@ namespace pegtl
                : m_size( reader.size() ),
                  m_data( static_cast< const char * >( ::mmap( nullptr, m_size, PROT_READ, MAP_FILE | MAP_PRIVATE, reader.m_fd, 0 ) ) )
          {
-            if ( intptr_t( m_data ) == -1 ) {
+            if ( m_size && intptr_t( m_data ) == -1 ) {
                PEGTL_THROW_INPUT_ERROR( "unable to mmap() file " << reader.m_source << " descriptor " << reader.m_fd );
             }
          }


### PR DESCRIPTION
Empty files are usually allowed, so file_mapper should not fail.