### PR TITLE
Support MSVC with partial C++11 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 version: '{branch}-{build}'
 
-os: Visual Studio 2015
+os:
+  - Visual Studio 2013
+  - Visual Studio 2015
 
 configuration: Release
 

--- a/pegtl/analysis/insert_guard.hh
+++ b/pegtl/analysis/insert_guard.hh
@@ -16,7 +16,7 @@ namespace PEGTL_NAMESPACE
       class insert_guard
       {
       public:
-         insert_guard( insert_guard && other ) noexcept
+         insert_guard( insert_guard && other ) PEGTL_NOEXCEPT
                : m_i( other.m_i ),
                  m_c( other.m_c )
          {

--- a/pegtl/ascii.hh
+++ b/pegtl/ascii.hh
@@ -10,7 +10,7 @@
 
 namespace PEGTL_NAMESPACE
 {
-   inline namespace ascii
+   PEGTL_INLINE_NAMESPACE(ascii)
    {
       struct alnum : internal::ranges< internal::peek_char, 'a', 'z', 'A', 'Z', '0', '9' > {};
       struct alpha : internal::ranges< internal::peek_char, 'a', 'z', 'A', 'Z' > {};
@@ -39,7 +39,8 @@ namespace PEGTL_NAMESPACE
       struct upper : internal::range< internal::result_on_found::SUCCESS, internal::peek_char, 'A', 'Z' > {};
       struct xdigit : internal::ranges< internal::peek_char, '0', '9', 'a', 'f', 'A', 'F' > {};
 
-   } // namespace ascii
+   }
+   PEGTL_END_INLINE_NAMESPACE(ascii)
 
 } // namespace PEGTL_NAMESPACE
 

--- a/pegtl/ascii.hh
+++ b/pegtl/ascii.hh
@@ -10,7 +10,8 @@
 
 namespace PEGTL_NAMESPACE
 {
-   PEGTL_INLINE_NAMESPACE(ascii)
+   // We could use `inline namespace` here but it does not work with MSVC from VS2013 or earlier.
+   namespace ascii
    {
       struct alnum : internal::ranges< internal::peek_char, 'a', 'z', 'A', 'Z', '0', '9' > {};
       struct alpha : internal::ranges< internal::peek_char, 'a', 'z', 'A', 'Z' > {};
@@ -40,7 +41,7 @@ namespace PEGTL_NAMESPACE
       struct xdigit : internal::ranges< internal::peek_char, '0', '9', 'a', 'f', 'A', 'F' > {};
 
    }
-   PEGTL_END_INLINE_NAMESPACE(ascii)
+   using namespace ascii;
 
 } // namespace PEGTL_NAMESPACE
 

--- a/pegtl/config.hh
+++ b/pegtl/config.hh
@@ -10,4 +10,17 @@
 #define PEGTL_NAMESPACE pegtl
 #endif
 
+// MSVC before VS2015 do not support some of C++11 features:
+#if defined(_MSC_VER) && (_MSC_VER < 1900) // msvc <2015
+#  define PEGTL_CONSTEXPR const
+#  define PEGTL_NOEXCEPT throw()
+#  define PEGTL_INLINE_NAMESPACE(NAME) namespace NAME
+#  define PEGTL_END_INLINE_NAMESPACE(NAME) using namespace ascii;
+#else
+#  define PEGTL_CONSTEXPR constexpr
+#  define PEGTL_NOEXCEPT noexcept
+#  define PEGTL_INLINE_NAMESPACE(NAME) inline namespace NAME
+#  define PEGTL_END_INLINE_NAMESPACE(NAME)
+#endif
+
 #endif

--- a/pegtl/config.hh
+++ b/pegtl/config.hh
@@ -14,13 +14,9 @@
 #if defined(_MSC_VER) && (_MSC_VER < 1900) // msvc <2015
 #  define PEGTL_CONSTEXPR const
 #  define PEGTL_NOEXCEPT throw()
-#  define PEGTL_INLINE_NAMESPACE(NAME) namespace NAME
-#  define PEGTL_END_INLINE_NAMESPACE(NAME) using namespace ascii;
 #else
 #  define PEGTL_CONSTEXPR constexpr
 #  define PEGTL_NOEXCEPT noexcept
-#  define PEGTL_INLINE_NAMESPACE(NAME) inline namespace NAME
-#  define PEGTL_END_INLINE_NAMESPACE(NAME)
 #endif
 
 #endif

--- a/pegtl/count_data.hh
+++ b/pegtl/count_data.hh
@@ -12,7 +12,7 @@ namespace PEGTL_NAMESPACE
 {
    struct count_data
    {
-      count_data( const std::size_t in_byte, const std::size_t in_line, const std::size_t in_byte_in_line, const char * in_data ) noexcept
+      count_data( const std::size_t in_byte, const std::size_t in_line, const std::size_t in_byte_in_line, const char * in_data ) PEGTL_NOEXCEPT
             : byte( in_byte ),
               line( in_line ),
               byte_in_line( in_byte_in_line ),

--- a/pegtl/cr_crlf_eol.hh
+++ b/pegtl/cr_crlf_eol.hh
@@ -10,7 +10,7 @@ namespace PEGTL_NAMESPACE
 {
    struct cr_crlf_eol
    {
-      static constexpr int ch = '\r';
+      static PEGTL_CONSTEXPR int ch = '\r';
 
       template< typename Input >
       static eol_pair match( Input & in )

--- a/pegtl/cr_eol.hh
+++ b/pegtl/cr_eol.hh
@@ -10,7 +10,7 @@ namespace PEGTL_NAMESPACE
 {
    struct cr_eol
    {
-      static constexpr int ch = '\r';
+      static PEGTL_CONSTEXPR int ch = '\r';
 
       template< typename Input >
       static eol_pair match( Input & in )

--- a/pegtl/crlf_eol.hh
+++ b/pegtl/crlf_eol.hh
@@ -10,7 +10,7 @@ namespace PEGTL_NAMESPACE
 {
    struct crlf_eol
    {
-      static constexpr int ch = '\n';
+      static PEGTL_CONSTEXPR int ch = '\n';
 
       template< typename Input >
       static eol_pair match( Input & in )

--- a/pegtl/internal/input_mark.hh
+++ b/pegtl/internal/input_mark.hh
@@ -15,13 +15,13 @@ namespace PEGTL_NAMESPACE
       template< rewind_mode M > class input_mark
       {
       public:
-         static constexpr rewind_mode next_rewind_mode = M;
+         static PEGTL_CONSTEXPR rewind_mode next_rewind_mode = M;
 
          explicit
          input_mark( const count_data & )
          { }
 
-         input_mark( input_mark && ) noexcept
+         input_mark( input_mark && ) PEGTL_NOEXCEPT
          { }
 
          input_mark( const input_mark & ) = delete;
@@ -36,15 +36,15 @@ namespace PEGTL_NAMESPACE
       template<> class input_mark< rewind_mode::REQUIRED >
       {
       public:
-         static constexpr rewind_mode next_rewind_mode = rewind_mode::ACTIVE;
+         static PEGTL_CONSTEXPR rewind_mode next_rewind_mode = rewind_mode::ACTIVE;
 
          explicit
-         input_mark( count_data & i ) noexcept
+         input_mark( count_data & i ) PEGTL_NOEXCEPT
                : m_count( i ),
                  m_input( & i )
          { }
 
-         input_mark( input_mark && i ) noexcept
+         input_mark( input_mark && i ) PEGTL_NOEXCEPT
                : m_count( i.m_count ),
                  m_input( i.m_input )
          {

--- a/pegtl/internal/range.hh
+++ b/pegtl/internal/range.hh
@@ -25,7 +25,7 @@ namespace PEGTL_NAMESPACE
          template< int Eol >
          struct can_match_eol
          {
-            static constexpr bool value = ( ( ( Lo <= Eol ) && ( Eol <= Hi ) ) == bool( R ) );
+            static PEGTL_CONSTEXPR bool value = ( ( ( Lo <= Eol ) && ( Eol <= Hi ) ) == bool( R ) );
          };
 
          // suppress warning with GCC 4.7

--- a/pegtl/internal/ranges.hh
+++ b/pegtl/internal/ranges.hh
@@ -22,7 +22,7 @@ namespace PEGTL_NAMESPACE
       template< int Eol, typename Char >
       struct ranges_impl< Eol, Char >
       {
-         static constexpr bool can_match_eol = false;
+         static PEGTL_CONSTEXPR bool can_match_eol = false;
 
          static bool match( const Char )
          {
@@ -33,7 +33,7 @@ namespace PEGTL_NAMESPACE
       template< int Eol, typename Char, Char Eq >
       struct ranges_impl< Eol, Char, Eq >
       {
-         static constexpr bool can_match_eol = ( Eq == Eol );
+         static PEGTL_CONSTEXPR bool can_match_eol = ( Eq == Eol );
 
          static bool match( const Char c )
          {
@@ -44,7 +44,7 @@ namespace PEGTL_NAMESPACE
       template< int Eol, typename Char, Char Lo, Char Hi, Char ... Cs >
       struct ranges_impl< Eol, Char, Lo, Hi, Cs ... >
       {
-         static constexpr bool can_match_eol = ( ( ( Lo <= Eol ) && ( Eol <= Hi ) ) || ranges_impl< Eol, Char, Cs ... >::can_match_eol );
+         static PEGTL_CONSTEXPR bool can_match_eol = ( ( ( Lo <= Eol ) && ( Eol <= Hi ) ) || ranges_impl< Eol, Char, Cs ... >::can_match_eol );
 
          static bool match( const Char c )
          {
@@ -60,7 +60,7 @@ namespace PEGTL_NAMESPACE
          template< int Eol >
          struct can_match_eol
          {
-            static constexpr bool value = ranges_impl< Eol, typename Peek::data_t, Cs ... >::can_match_eol;
+            static PEGTL_CONSTEXPR bool value = ranges_impl< Eol, typename Peek::data_t, Cs ... >::can_match_eol;
          };
 
          template< typename Input >

--- a/pegtl/lf_crlf_eol.hh
+++ b/pegtl/lf_crlf_eol.hh
@@ -10,7 +10,7 @@ namespace PEGTL_NAMESPACE
 {
    struct lf_crlf_eol
    {
-      static constexpr int ch = '\n';
+      static PEGTL_CONSTEXPR int ch = '\n';
 
       template< typename Input >
       static eol_pair match( Input & in )

--- a/pegtl/lf_eol.hh
+++ b/pegtl/lf_eol.hh
@@ -10,7 +10,7 @@ namespace PEGTL_NAMESPACE
 {
    struct lf_eol
    {
-      static constexpr int ch = '\n';
+      static PEGTL_CONSTEXPR int ch = '\n';
 
       template< typename Input >
       static eol_pair match( Input & in )


### PR DESCRIPTION
MSVC before VS2015 do not support some of C++11 features, namely:
- noexcept
- constexpr
- inline namespace


This patch applies a workaround to this issue.